### PR TITLE
Fix JSON display in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ $ npm install --save-dev gulp-load-tasks
 Given a `package.json` file that has some dependencies within:
 
 ```json
-"dependencies": {
-    "gulp-jshint": "*",
-    "gulp-concat": "*"
+{
+    "dependencies": {
+        "gulp-jshint": "*",
+        "gulp-concat": "*"
+    }
 }
 ```
 


### PR DESCRIPTION
Feel free to ignore this, but by adding some surrounding curly braces, GitHub's syntax highlighting looks a bit nicer. :)
