### PR TITLE
Added repository link for easier access to the plugin from npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "mocha test.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jackfranklin/gulp-load-tasks.git"
+  },
   "keywords": [
     "gulpplugin",
     "gulp"


### PR DESCRIPTION
Noticed this wasn't in the `package.json` file, there's no way from either [the gulp plugin directory](http://gratimax.github.io/search-gulp-plugins/) or npm to find the original repository.
