### PR TITLE
Using getters to lazy load modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,14 @@ module.exports = function(options) {
     requireName = camelizePluginName ? camelize(requireName) : requireName;
 
     if (lazy) {
-      finalObject[requireName] = function () {
-        var fn = finalObject[requireName] = require(name);
-        return fn.apply(this, arguments);
-      };
+      Object.defineProperty(finalObject, requireName, {
+        get: (function(theModule) {
+          return function() {
+            theModule = theModule || require(name)
+            return theModule;
+          }
+        })()
+      });
     } else {
       finalObject[requireName] = require(name);
     }

--- a/test.js
+++ b/test.js
@@ -21,6 +21,10 @@ var gulpLoadPlugins = (function () {
     "gulp-foo-bar": wrapInFunc({ name: "foo-bar" }),
     "gulp-spy": spyPlugin,
     "jack-foo": wrapInFunc({ name: "jack-foo" }),
+    "gulp-insert": {
+      'append':  wrapInFunc({ name: "insert.append" }),
+      'wrap':   wrapInFunc({ name: "insert.wrap" })
+    }
   });
 })();
 
@@ -34,7 +38,8 @@ var commonTests = function (lazy) {
       config: {
         dependencies: {
           "gulp-foo": "1.0.0",
-          "gulp-bar": "*"
+          "gulp-bar": "*",
+          "gulp-insert": "*"
         }
       }
     });
@@ -44,6 +49,12 @@ var commonTests = function (lazy) {
     });
     assert.deepEqual(x.bar(), {
       name: "bar"
+    });
+    assert.deepEqual(x.insert.wrap(), {
+      name: "insert.wrap"
+    });
+    assert.deepEqual(x.insert.append(), {
+      name: "insert.append"
     });
   });
 
@@ -108,20 +119,6 @@ describe("loading plugins", function() {
   describe("lazily", function () {
     commonTests(true);
 
-    it('should not require plugin before use', function () {
-      var $ = gulpLoadPlugins({
-        lazy: true,
-        config: {
-          dependencies: {
-            "gulp-spy": "*"
-          }
-        }
-      });
-
-      // The current value is not the plugin.
-      assert.notEqual($.spy, spyPlugin);
-    });
-
     it('should proxy context and arguments', function () {
       var $ = gulpLoadPlugins({
         lazy: true,
@@ -141,22 +138,6 @@ describe("loading plugins", function() {
       assert.equal(context, result[0]);
       assert.equal(arg1, result[1]);
       assert.equal(arg2, result[2]);
-    });
-
-    it('once called, the plugin should be directly available', function () {
-      var $ = gulpLoadPlugins({
-        lazy: true,
-        config: {
-          dependencies: {
-            "gulp-spy": "*"
-          }
-        }
-      });
-
-      $.spy();
-
-      // Now it is the plugin.
-      assert.equal($.spy, spyPlugin);
     });
   });
 });


### PR DESCRIPTION
I faced an issue by using this plugin and gulp-insert.

Indeed, gulp-insert doens't expose a function but several in an hash.

This commit fixes the issue by using Object.defineProperty.

Unfortunately, i had to remove some test since it isn't possible enymaroe to test if the property contains the "wrapping" function or the plugin one.
