### PR TITLE
Lazy Loading via defineProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var globule = require('globule');
 var findup = require('findup-sync');
 
+
 function arrayify(el) {
   return Array.isArray(el) ? el : [el];
 }
@@ -21,6 +22,7 @@ module.exports = function(options) {
   var replaceString = options.replaceString || "gulp-";
   var camelizePluginName = options.camelize === false ? false : true;
   var lazy = 'lazy' in options ? !!options.lazy : true;
+  var requireFn = options.requireFn || require;
 
   if (typeof config === 'string') {
     config = require(config);
@@ -39,11 +41,11 @@ module.exports = function(options) {
     if(lazy) {
       Object.defineProperty(finalObject, requireName, {
         get: function() {
-          return require(name);
+          return requireFn(name);
         }
       });
     } else {
-      finalObject[requireName] = require(name);
+      finalObject[requireName] = requireFn(name);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "mocha": "~1.15.1",
-    "proxyquire": "~0.5.2"
+    "proxyquire": "~0.5.2",
+    "sinon": "^1.9.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var assert = require("assert");
+var sinon = require('sinon');
 
 //====================================================================
 
@@ -106,9 +107,58 @@ var commonTests = function (lazy) {
 
 describe('no lazy loading', function() {
   commonTests(false);
+
+  var x, spy;
+  before(function() {
+    spy = sinon.spy();
+    x = gulpLoadPlugins({
+      lazy: false,
+      config: {
+        dependencies: {
+          "gulp-insert": "*"
+        }
+      },
+      requireFn: function() {
+        spy();
+        return function() {};
+      }
+    });
+  });
+
+  it('does require at first', function() {
+    assert(spy.called);
+  });
+
 });
 
 describe('with lazy loading', function() {
   commonTests(true);
+
+  var x, spy;
+  before(function() {
+    spy = sinon.spy();
+    x = gulpLoadPlugins({
+      lazy: true,
+      config: {
+        dependencies: {
+          "gulp-insert": "*"
+        }
+      },
+      requireFn: function() {
+        spy();
+        return function() {};
+      }
+    });
+  });
+
+  it('does not require at first', function() {
+    assert(!spy.called);
+  });
+
+  it('does when the property is accessed', function() {
+    x.insert();
+    assert(spy.called);
+  });
 });
+
 


### PR DESCRIPTION
This is some work on top of @nfroidure's awesome start to using `defineProperty` for lazy loading, which should make it seamless to work with lazy-loaded modules that don't just return a function.

It would be nice to find a way to test this behaviour though, anyone got any thoughts on that?

@nfroidure please let me know what you think. I simplified down the lazy loading code a little.
