### PR TITLE
Switch out globule with multimatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var globule = require('globule');
+var multimatch = require('multimatch');
 var findup = require('findup-sync');
 
 function arrayify(el) {
@@ -34,7 +34,7 @@ module.exports = function(options) {
 
   pattern.push('!gulp-load-plugins');
 
-  globule.match(pattern, names).forEach(function(name) {
+  multimatch(names, pattern).forEach(function(name) {
     var requireName = name.replace(replaceString, '');
     requireName = camelizePluginName ? camelize(requireName) : requireName;
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "findup-sync": "^0.1.2",
-    "globule": "^0.2.0"
+    "multimatch": "^0.3.0"
   },
   "devDependencies": {
     "mocha": "^1.18.2",


### PR DESCRIPTION
[Multimatch](https://github.com/sindresorhus/multimatch) is just a thin wrapper upon minimatch adding support for multiple patterns. While Globule is this bloated utility lib IMHO trying to do too many things.

It should work exactly the same however.
