### PR TITLE
Show a nice error if plugin can't find config file

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ module.exports = function(options) {
     config = require(config);
   }
 
+  if(!config) {
+    throw new Error('Could not find dependencies. Do you have a package.json file in your project?');
+  }
+
   var names = scope.reduce(function(result, prop) {
     return result.concat(Object.keys(config[prop] || {}));
   }, []);

--- a/test.js
+++ b/test.js
@@ -21,11 +21,23 @@ var gulpLoadPlugins = (function() {
     'gulp-insert': {
       'append':  wrapInFunc({ name: 'insert.append' }),
       'wrap':   wrapInFunc({ name: 'insert.wrap' })
-    }
+    },
+    'findup-sync': function() { return null; }
   });
 })();
 
 //====================================================================
+
+describe('configuration', function() {
+  it('throws a nice error if no configuration is found', function() {
+    assert.throws(function() {
+      gulpLoadPlugins({
+        config: null
+      });
+    }, /Could not find dependencies. Do you have a package.json file in your project?/);
+  });
+});
+
 
 // Contains common tests with and without lazy mode.
 var commonTests = function(lazy) {


### PR DESCRIPTION
Previously if the user didn't have a package.json this would throw a
horrible and very unclear error. This adds a nicer message.
