### PR TITLE
Fixed bug where config option wasn't that useful in child dirs.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+/node_modules

--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ module.exports = function(options) {
     requireFn = options.requireFn;
   } else if(typeof config === 'string') {
     requireFn = function (name) {
-      return require(path.join(path.dirname(config), 'node_modules', name));
+      var searchFor = path.join('node_modules', name);
+      return require(findup(searchFor, {cwd: path.dirname(config)}));
     };
   } else {
     requireFn = require;

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function camelize(str) {
 
 module.exports = function(options) {
   var finalObject = {};
+  var configObject, requireFn;
   options = options || {};
 
   var pattern = arrayify(options.pattern || ['gulp-*', 'gulp.*']);
@@ -23,19 +24,26 @@ module.exports = function(options) {
   var replaceString = options.replaceString || /^gulp(-|\.)/;
   var camelizePluginName = options.camelize === false ? false : true;
   var lazy = 'lazy' in options ? !!options.lazy : true;
-  var requireFn = options.requireFn || require;
   var renameObj = options.rename || {};
 
-  if (typeof config === 'string') {
-    config = require(config);
+  if(typeof options.requireFn === 'function') {
+    requireFn = options.requireFn;
+  } else if(typeof config === 'string') {
+    requireFn = function (name) {
+      return require(path.join(path.dirname(config), 'node_modules', name));
+    };
+  } else {
+    requireFn = require;
   }
 
-  if(!config) {
+  configObject = (typeof config === 'string') ? require(config) : config;
+
+  if(!configObject) {
     throw new Error('Could not find dependencies. Do you have a package.json file in your project?');
   }
 
   var names = scope.reduce(function(result, prop) {
-    return result.concat(Object.keys(config[prop] || {}));
+    return result.concat(Object.keys(configObject[prop] || {}));
   }, []);
 
   pattern.push('!gulp-load-plugins');

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function camelize(str) {
 
 module.exports = function(options) {
   var finalObject = {};
-  var configObject, requireFn;
+  var configObject;
+  var requireFn;
   options = options || {};
 
   var pattern = arrayify(options.pattern || ['gulp-*', 'gulp.*']);
@@ -30,6 +31,8 @@ module.exports = function(options) {
     requireFn = options.requireFn;
   } else if(typeof config === 'string') {
     requireFn = function (name) {
+      // This searches up from the specified package.json file, making sure
+      // the config option behaves as expected. See issue #56.
       var searchFor = path.join('node_modules', name);
       return require(findup(searchFor, {cwd: path.dirname(config)}));
     };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "description": "Automatically load any gulp plugins in your package.json",
   "scripts": {
-    "test": "mocha test.js"
+    "test": "mocha"
   },
   "files": [
     "index.js"
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "findup-sync": "^0.2.1",
+    "gulp-uglify": "^1.1.0",
     "multimatch": "2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "kombucha",
     "Nicolas Froidure",
     "Sindre Sorhus",
-    "Julien Fontanet <julien.fontanet@vates.fr>"
+    "Julien Fontanet <julien.fontanet@vates.fr>",
+    "Callum Macrae"
   ],
   "license": "MIT",
   "dependencies": {
     "findup-sync": "^0.2.1",
-    "gulp-uglify": "^1.1.0",
     "multimatch": "2.0.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ var gulpLoadPlugins = (function() {
 
   var proxyquire = require('proxyquire').noCallThru();
 
-  return proxyquire('./', {
+  return proxyquire('../', {
     'gulp-foo': wrapInFunc({ name: 'foo' }),
     'gulp-bar': wrapInFunc({ name: 'bar' }),
     'gulp-foo-bar': wrapInFunc({ name: 'foo-bar' }),
@@ -185,5 +185,12 @@ describe('with lazy loading', function() {
   it('does when the property is accessed', function() {
     x.insert();
     assert(spy.called);
+  });
+});
+
+describe('requiring from another directory', function() {
+  it('allows you to use in a lower directory', function() {
+    var plugins = require('../')();
+    assert.ok(typeof plugins.test === 'function');
   });
 });

--- a/test/node_modules/gulp-test/index.js
+++ b/test/node_modules/gulp-test/index.js
@@ -1,0 +1,1 @@
+module.exports = function () {};

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "gulp-test": "*"
+  }
+}


### PR DESCRIPTION
Fixes #56. I feel this probably needs a test, but I'm not sure how to
test it without adding a test dir and extra files. It works in my case,
and none of the existing tests break.

To test, just make a child directory with a gulpfile in and a couple
gulp-* dependencies, and require gulp-load-plugins using '../'. Then
it won't be able to find the dependencies until you merge this PR.

I can get rid of the editorconfig stuff if you want :)