### PR TITLE
Throw an informative error on missing modules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,12 @@ module.exports = function(options) {
       // This searches up from the specified package.json file, making sure
       // the config option behaves as expected. See issue #56.
       var searchFor = path.join('node_modules', name);
-      return require(findup(searchFor, {cwd: path.dirname(config)}));
+      var src = findup(searchFor, {cwd: path.dirname(config)});
+      if (src !== null) {
+      	return require(src);
+      } else {
+      	throw new Error('Cannot find `' + name + '` in your node_modules!');
+      }
     };
   } else {
     requireFn = require;

--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ module.exports = function(options) {
       var searchFor = path.join('node_modules', name);
       var src = findup(searchFor, {cwd: path.dirname(config)});
       if (src !== null) {
-      	return require(src);
+        return require(src);
       } else {
-      	throw new Error('Cannot find `' + name + '` in your node_modules!');
+        throw new Error('Cannot find `' + name + '` in your node_modules!');
       }
     };
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -198,7 +198,15 @@ describe('with lazy loading', function() {
   });
 });
 
-describe('requiring from another directory', function() {
+describe('common functionality', function () {
+  it('throws a sensible error when not found', function () {
+    var x = gulpLoadPlugins({ config: __dirname + '/package.json' });
+
+    assert.throws(function () {
+      x.oops();
+    }, (/Cannot find `gulp-oops`/));
+  });
+
   it('allows you to use in a lower directory', function() {
     var plugins = require('../')();
     assert.ok(typeof plugins.test === 'function');

--- a/test/package.json
+++ b/test/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "gulp-test": "*"
+    "gulp-test": "*",
+    "gulp-oops": "*"
   }
 }


### PR DESCRIPTION
Previously, if you forgot to `npm install` after a pull and gulped, it'd throw a rather cryptic error when a package was not found:

```
 AssertionError: path must be a string
    at Module.require (module.js:362:3)
    at require (module.js:380:17)
    at requireFn (C:\Users\Connor\Documents\GitHub\beam-widgets\node_modules\gulp-load-plugins\index.js:37:14)
    at Object.defineProperty.get (C:\Users\Connor\Documents\GitHub\beam-widgets\node_modules\gulp-load-plugins\index.js:59:18)
...
```

Now, it throws a nice one!
```
Error: Cannot find `gulp-istanbul` in your node_modules!
```