### PR TITLE
allow to load modules from NODE_PATH

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function(options) {
       // This searches up from the specified package.json file, making sure
       // the config option behaves as expected. See issue #56.
       var searchFor = path.join('node_modules', name);
-      return require(findup(searchFor, {cwd: path.dirname(config)}));
+      return require(findup(searchFor, {cwd: path.dirname(config)}) || name);
     };
   } else {
     requireFn = require;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.0",
   "description": "Automatically load any gulp plugins in your package.json",
   "scripts": {
-    "test": "mocha"
+    "test": "NODE_PATH=test/global_modules mocha"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "Sindre Sorhus",
     "Julien Fontanet <julien.fontanet@vates.fr>",
     "Callum Macrae",
-    "Hutson Betts"
+    "Hutson Betts",
+    "Christian Maniewski"
   ],
   "license": "MIT",
   "dependencies": {

--- a/test/global_modules/gulp-test-global/index.js
+++ b/test/global_modules/gulp-test-global/index.js
@@ -1,0 +1,1 @@
+module.exports = function () {};

--- a/test/index.js
+++ b/test/index.js
@@ -204,3 +204,13 @@ describe('requiring from another directory', function() {
     assert.ok(typeof plugins.test === 'function');
   });
 });
+
+describe('requiring from global directory', function() {
+  it('allows you to use the NODE_PATH directory', function() {
+    if (process.env.NODE_PATH !== 'test/global_modules') {
+      throw new Error('No NODE_PATH found. Please run the tests using npm test.');
+    }
+    var plugins = require('../')();
+    assert.ok(typeof plugins.testGlobal === 'function');
+  });
+});

--- a/test/package.json
+++ b/test/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "gulp-test": "*"
+    "gulp-test": "*",
+    "gulp-test-global": "*"
   }
 }


### PR DESCRIPTION
This PR enables the possibility to let require() look for the NODE_PATH (which it does by default), by just passing in the module name if it was not found in the working directory.

Sorry about the weird modifications I had to make to test this behavior. I did not know how else to test it (if you have a better idea, feel free to modify this PR). I couldn't set the NODE_PATH programmatically so that require picks it up later in the program.