### PR TITLE
Replaced findup with resolve.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var multimatch = require('multimatch');
 var findup = require('findup-sync');
 var path = require('path');
+var resolve = require('resolve');
 
 function arrayify(el) {
   return Array.isArray(el) ? el : [el];
@@ -33,14 +34,8 @@ module.exports = function(options) {
     requireFn = function (name) {
       // This searches up from the specified package.json file, making sure
       // the config option behaves as expected. See issue #56.
-      var searchFor = path.join('node_modules', name);
-
-      var src = findup(searchFor, {cwd: path.dirname(config)}) || name;
-      if (src !== null) {
-        return require(src);
-      } else {
-        throw new Error('Cannot find `' + name + '` in your node_modules!');
-      }
+      var src = resolve.sync(name, { basedir: path.dirname(config) });
+      return require(src);
     };
   } else {
     requireFn = require;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "license": "MIT",
   "dependencies": {
     "findup-sync": "^0.2.1",
-    "multimatch": "2.0.0"
+    "multimatch": "2.0.0",
+    "resolve": "^1.1.6"
   },
   "devDependencies": {
     "jshint": "^2.5.1",

--- a/test/index.js
+++ b/test/index.js
@@ -212,13 +212,3 @@ describe('common functionality', function () {
     assert.ok(typeof plugins.test === 'function');
   });
 });
-
-describe('requiring from global directory', function() {
-  it('allows you to use the NODE_PATH directory', function() {
-    if (process.env.NODE_PATH !== 'test/global_modules') {
-      throw new Error('No NODE_PATH found. Please run the tests using npm test.');
-    }
-    var plugins = require('../')();
-    assert.ok(typeof plugins.testGlobal === 'function');
-  });
-});


### PR DESCRIPTION
The actual code is much nicer.

This has the side effect that it drops support for NODE_PATH, because it isn't supported by resolve: substack/node-resolve#47. However, according to the Node.js docs, you're not supposed to use NODE_PATH anyway: https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders

I can probably work around if you want NODE_PATH support or you don't want to break BC, but it would make the code quite a bit longer (it would involve a try-catch in a try-catch!)

closes #74