### PR TITLE
Added debug option to log loading and renaming

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = function(options) {
     }
 
     if(DEBUG) {
-      logDebug('gulp-load-plugins: renaming ' + name + ' into ' + requireName, chalk.yellow);
+      logDebug('gulp-load-plugins: renaming ' + name + ' to ' + requireName, chalk.yellow);
     }
 
     return requireName;
@@ -113,7 +113,7 @@ module.exports = function(options) {
     } else {
       defineProperty(finalObject, getRequireName(name), name);
     }
-    
+
   });
 
   return finalObject;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var multimatch = require('multimatch');
 var findup = require('findup-sync');
 var path = require('path');
 var resolve = require('resolve');
-var chalk = require('chalk');
+var gutil = require('gulp-util');
 
 function arrayify(el) {
   return Array.isArray(el) ? el : [el];
@@ -30,7 +30,7 @@ module.exports = function(options) {
   var lazy = 'lazy' in options ? !!options.lazy : true;
   var renameObj = options.rename || {};
 
-  logDebug('gulp-load-plugins: Debug enabled with options: ' + JSON.stringify(options), chalk.green);
+  logDebug('Debug enabled with options: ' + JSON.stringify(options));
 
   var renameFn = options.renameFn || function (name) {
     name = name.replace(replaceString, '');
@@ -60,27 +60,27 @@ module.exports = function(options) {
     return result.concat(Object.keys(configObject[prop] || {}));
   }, []);
 
-  logDebug('gulp-load-plugins: ' + names.length + ' plugin(s) found: ' + names.join(' '), chalk.green);
+  logDebug(names.length + ' plugin(s) found: ' + names.join(' '));
 
   pattern.push('!gulp-load-plugins');
 
-  function logDebug(message, chalkColor) {
+  function logDebug(message) {
     if(DEBUG) {
-      console.log(chalkColor(message));
+      gutil.log(gutil.colors.green('gulp-load-plugins: ' + message));
     }
   }
 
   function defineProperty(object, requireName, name) {
     if(lazy) {
-      logDebug('gulp-load-plugins: lazyload: adding property ' + requireName, chalk.green);
+      logDebug('lazyload: adding property ' + requireName);
       Object.defineProperty(object, requireName, {
         get: function() {
-          logDebug('gulp-load-plugins: lazyload: requiring ' + name + '...', chalk.green);
+          logDebug('lazyload: requiring ' + name + '...');
           return requireFn(name);
         }
       });
     } else {
-      logDebug('gulp-load-plugins: requiring ' + name + '...', chalk.green);
+      logDebug('requiring ' + name + '...');
       object[requireName] = requireFn(name);
     }
   }
@@ -94,7 +94,7 @@ module.exports = function(options) {
       requireName = renameFn(name);
     }
 
-    logDebug('gulp-load-plugins: renaming ' + name + ' to ' + requireName, chalk.yellow);
+    logDebug('renaming ' + name + ' to ' + requireName);
 
     return requireName;
   }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
   var requireFn;
   options = options || {};
 
-  var DEBUG = options.DEBUG;
+  var DEBUG = options.DEBUG || false;
   var pattern = arrayify(options.pattern || ['gulp-*', 'gulp.*', '@*/gulp{-,.}*']);
   var config = options.config || findup('package.json', {cwd: parentDir});
   var scope = arrayify(options.scope || ['dependencies', 'devDependencies', 'peerDependencies']);
@@ -29,6 +29,8 @@ module.exports = function(options) {
   var camelizePluginName = options.camelize !== false;
   var lazy = 'lazy' in options ? !!options.lazy : true;
   var renameObj = options.rename || {};
+
+  logDebug('gulp-load-plugins: Debug enabled with options: ' + JSON.stringify(options), chalk.green);
 
   var renameFn = options.renameFn || function (name) {
     name = name.replace(replaceString, '');
@@ -58,26 +60,27 @@ module.exports = function(options) {
     return result.concat(Object.keys(configObject[prop] || {}));
   }, []);
 
+  logDebug('gulp-load-plugins: ' + names.length + ' plugin(s) found: ' + names.join(' '), chalk.green);
+
   pattern.push('!gulp-load-plugins');
 
   function logDebug(message, chalkColor) {
-    console.log(chalkColor(message));
+    if(DEBUG) {
+      console.log(chalkColor(message));
+    }
   }
 
   function defineProperty(object, requireName, name) {
     if(lazy) {
+      logDebug('gulp-load-plugins: lazyload: adding property ' + requireName, chalk.green);
       Object.defineProperty(object, requireName, {
         get: function() {
-          if(DEBUG) {
-            logDebug('gulp-load-plugins: lazyloading ' + name + '...', chalk.green);
-          }
+          logDebug('gulp-load-plugins: lazyload: requiring ' + name + '...', chalk.green);
           return requireFn(name);
         }
       });
     } else {
-      if(DEBUG) {
-        logDebug('gulp-load-plugins: loading ' + name + '...', chalk.green);
-      }
+      logDebug('gulp-load-plugins: requiring ' + name + '...', chalk.green);
       object[requireName] = requireFn(name);
     }
   }
@@ -91,9 +94,7 @@ module.exports = function(options) {
       requireName = renameFn(name);
     }
 
-    if(DEBUG) {
-      logDebug('gulp-load-plugins: renaming ' + name + ' to ' + requireName, chalk.yellow);
-    }
+    logDebug('gulp-load-plugins: renaming ' + name + ' to ' + requireName, chalk.yellow);
 
     return requireName;
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "chalk": "^1.1.1",
     "findup-sync": "^0.2.1",
     "multimatch": "2.0.0",
     "resolve": "^1.1.6"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "Callum Macrae",
     "Hutson Betts",
     "Christian Maniewski",
-    "Connor Peet"
+    "Connor Peet",
+    "Dorian Camilleri"
   ],
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "chalk": "^1.1.1",
     "findup-sync": "^0.2.1",
+    "gulp-util": "^3.0.7",
     "multimatch": "2.0.0",
     "resolve": "^1.1.6"
   },


### PR DESCRIPTION
Hi Jack,

Saw your tweet and issue #90  and added some logs for loading and renaming packages. Also added chalk for fancy colors (used green for loading and yellow for renaming). Didn't add tests given that it's just console logs.
Let me know if you'd like anything else to be logged :) !

Cheers,
Dorian.