### PR TITLE
Changed 'configObject' initilization statement to call 'requireFn()' …

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function(options) {
     requireFn = require;
   }
 
-  configObject = (typeof config === 'string') ? require(config) : config;
+  configObject = (typeof config === 'string') ? requireFn(config) : config;
 
   if(!configObject) {
     throw new Error('Could not find dependencies. Do you have a package.json file in your project?');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "Connor Peet",
     "Dorian Camilleri",
     "Carlos Henrique",
-    "iamfrontender <iamfrontender@gmail.com>"
+    "iamfrontender <iamfrontender@gmail.com>",
+    "mwessner"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Changed 'configObject' initilization statement to call 'requireFn()' function (instead of 'require()') when the 'config' option is provided as a string.

I have noticed that my Gulp plugins are not loaded when I provide the 'config' option. I have set the option to "package.json" (which is default) and it resolved to some other (undetermined) 'package.json' file. When 'config' option is not provided it resolves correctly since 'config' is then initialized by result of calling 'findup()' - which returns the full path to 'package.json' file inside the project folder (the one I wanted to target). It seems that resolving the filepath and setting the 'requireFn' is the goal of 'else if' block before the 'configObject' initialization, so it makes sense to utilize 'requireFn()' function instead of 'require()'.