### PR TITLE
Update dependencies to match gulp 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can pass in an object of options that are shown below: (the values for the k
 
 ```js
 gulpLoadPlugins({
+    DEBUG: false, // when set to true, the plugin will log info to console. Useful for bug reporting and issue debugging
     pattern: ['gulp-*', 'gulp.*'], // the glob(s) to search for
     config: 'package.json', // where to find the plugins, by default searched up from process.cwd()
     scope: ['dependencies', 'devDependencies', 'peerDependencies'], // which keys in the config to look within
@@ -65,8 +66,7 @@ gulpLoadPlugins({
     camelize: true, // if true, transforms hyphenated plugins names to camel case
     lazy: true, // whether the plugins should be lazy loaded on demand
     rename: {}, // a mapping of plugins to rename
-    renameFn: function (name) { ... }, // a function to handle the renaming of plugins (the default works)
-    DEBUG: true // when set to true and using gulp-cli flag -LLLL, the plugin will log info to console. Useful for bug reporting and issue debugging
+    renameFn: function (name) { ... } // a function to handle the renaming of plugins (the default works)
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ You can pass in an object of options that are shown below: (the values for the k
 
 ```js
 gulpLoadPlugins({
-    DEBUG: false, // when set to true, the plugin will log info to console. Useful for bug reporting and issue debugging
     pattern: ['gulp-*', 'gulp.*'], // the glob(s) to search for
     config: 'package.json', // where to find the plugins, by default searched up from process.cwd()
     scope: ['dependencies', 'devDependencies', 'peerDependencies'], // which keys in the config to look within
@@ -66,7 +65,8 @@ gulpLoadPlugins({
     camelize: true, // if true, transforms hyphenated plugins names to camel case
     lazy: true, // whether the plugins should be lazy loaded on demand
     rename: {}, // a mapping of plugins to rename
-    renameFn: function (name) { ... } // a function to handle the renaming of plugins (the default works)
+    renameFn: function (name) { ... }, // a function to handle the renaming of plugins (the default works)
+    DEBUG: true // when set to true and using gulp-cli flag -LLLL, the plugin will log info to console. Useful for bug reporting and issue debugging
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var micromatch = require('micromatch');
 var unique = require('array-unique');
 var findup = require('findup-sync');
 var resolve = require('resolve');
-var log = require('fancy-log');
+var logger = require('gulplog');
 var path = require('path');
 
 function arrayify(el) {
@@ -22,7 +22,7 @@ module.exports = function(options) {
   var requireFn;
   options = options || {};
 
-  var DEBUG = options.DEBUG || false;
+  var DEBUG = typeof options.DEBUG === 'undefined' ? true : options.DEBUG;
   var pattern = arrayify(options.pattern || ['gulp-*', 'gulp.*', '@*/gulp{-,.}*']);
   var config = options.config || findup('package.json', {cwd: parentDir});
   var scope = arrayify(options.scope || ['dependencies', 'devDependencies', 'peerDependencies']);
@@ -67,7 +67,7 @@ module.exports = function(options) {
 
   function logDebug(message) {
     if(DEBUG) {
-      log('gulp-load-plugins: ' + message);
+      logger.debug('gulp-load-plugins: ' + message);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
-var multimatch = require('multimatch');
+var micromatch = require('micromatch');
+var unique = require('array-unique');
 var findup = require('findup-sync');
-var path = require('path');
 var resolve = require('resolve');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
+var path = require('path');
 
 function arrayify(el) {
   return Array.isArray(el) ? el : [el];
@@ -66,7 +67,7 @@ module.exports = function(options) {
 
   function logDebug(message) {
     if(DEBUG) {
-      gutil.log(gutil.colors.green('gulp-load-plugins: ' + message));
+      log('gulp-load-plugins: ' + message);
     }
   }
 
@@ -108,7 +109,7 @@ module.exports = function(options) {
   var scopeTest = new RegExp('^@');
   var scopeDecomposition = new RegExp('^@(.+)/(.+)');
 
-  multimatch(names, pattern).forEach(function(name) {
+  unique(micromatch(names, pattern)).forEach(function(name) {
     var decomposition;
     if(scopeTest.test(name)) {
       decomposition = scopeDecomposition.exec(name);

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(options) {
   var requireFn;
   options = options || {};
 
-  var DEBUG = typeof options.DEBUG === 'undefined' ? true : options.DEBUG;
+  var DEBUG = options.DEBUG || false;
   var pattern = arrayify(options.pattern || ['gulp-*', 'gulp.*', '@*/gulp{-,.}*']);
   var config = options.config || findup('package.json', {cwd: parentDir});
   var scope = arrayify(options.scope || ['dependencies', 'devDependencies', 'peerDependencies']);

--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
     "Connor Peet",
     "Dorian Camilleri",
     "Carlos Henrique",
-    "iamfrontender <iamfrontender@gmail.com>"
+    "iamfrontender <iamfrontender@gmail.com>",
+    "Brian Woodward"
   ],
   "dependencies": {
     "array-unique": "^0.2.1",
-    "fancy-log": "^1.2.0",
     "findup-sync": "^0.4.0",
     "gulp-util": "^3.0.7",
+    "gulplog": "^1.0.0",
     "micromatch": "^2.3.8",
     "resolve": "^1.1.7"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "npm run lint && NODE_PATH=test/global_modules mocha",
     "lint": "eslint **/*.js"
   },
-  "license": "mit",
+  "license": "MIT",
   "files": [
     "index.js"
   ],
@@ -34,12 +34,13 @@
     "Carlos Henrique",
     "iamfrontender <iamfrontender@gmail.com>"
   ],
-  "license": "MIT",
   "dependencies": {
-    "findup-sync": "^0.2.1",
+    "array-unique": "^0.2.1",
+    "fancy-log": "^1.2.0",
+    "findup-sync": "^0.4.0",
     "gulp-util": "^3.0.7",
-    "multimatch": "2.0.0",
-    "resolve": "^1.1.6"
+    "micromatch": "^2.3.8",
+    "resolve": "^1.1.7"
   },
   "devDependencies": {
     "eslint": "^1.10.3",


### PR DESCRIPTION
This PR is to update dependencies to match some that are used in gulp 4.

- removes `gulp-util`
- uses `fancy-log` for DEBUG logging
- updates `findup-sync`
- uses `micromatch` (used in `findup-sync` and `chokidar` for `gulp.watch`)

Since this is an attempt at consolidating common dependencies, I removed the green coloring around the logging messages. If you'd like to keep that, I can add something for it.