### PR TITLE
Uses has-gulplog

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
+var hasGulplog = require('has-gulplog');
 var micromatch = require('micromatch');
 var unique = require('array-unique');
 var findup = require('findup-sync');
 var resolve = require('resolve');
-var logger = require('gulplog');
 var path = require('path');
 
 function arrayify(el) {
@@ -14,6 +14,21 @@ function camelize(str) {
   return str.replace(/-(\w)/g, function(m, p1) {
     return p1.toUpperCase();
   });
+}
+
+// code from https://github.com/gulpjs/gulp-util/blob/master/lib/log.js
+// to use the same functionality as gulp-util for backwards compatibility
+// with gulp 3x cli
+function logger() {
+  if(hasGulplog()){
+    // specifically deferring loading here to keep from registering it globally
+    var gulplog = require('gulplog');
+    gulplog.info.apply(gulplog, arguments);
+  } else {
+    // specifically defering loading because it might not be used
+    var fancylog = require('fancy-log');
+    fancylog.apply(null, arguments);
+  }
 }
 
 module.exports = function(options) {
@@ -67,7 +82,7 @@ module.exports = function(options) {
 
   function logDebug(message) {
     if(DEBUG) {
-      logger.debug('gulp-load-plugins: ' + message);
+      logger('gulp-load-plugins: ' + message);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -37,13 +37,15 @@
   ],
   "dependencies": {
     "array-unique": "^0.2.1",
+    "fancy-log": "^1.2.0",
     "findup-sync": "^0.4.0",
-    "gulp-util": "^3.0.7",
     "gulplog": "^1.0.0",
+    "has-gulplog": "^0.1.0",
     "micromatch": "^2.3.8",
     "resolve": "^1.1.7"
   },
   "devDependencies": {
+    "capture-stream": "^0.1.2",
     "eslint": "^1.10.3",
     "mocha": "^2.1.0",
     "proxyquire": "^1.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
 var sinon = require('sinon');
+var capture = require('capture-stream');
 
 //====================================================================
 
@@ -52,7 +53,7 @@ describe('configuration', function() {
             'bar': '*',
             'gulp-bar': '~0.0.12'
           }
-        }  
+        }
       });
     }, /Could not define the property "bar", you may have repeated dependencies in your package.json like "gulp-bar" and "bar"/);
   });
@@ -150,6 +151,27 @@ var commonTests = function(lazy) {
     });
 
     assert.deepEqual(x.bar(), { name: 'foo' });
+  });
+
+  it('outputs debug statements', function() {
+    var restore = capture(process.stdout);
+    try {
+      var x = gulpLoadPlugins({
+        lazy: lazy,
+        DEBUG: true,
+        config: { dependencies: { 'gulp-foo': '*'} }
+      });
+
+      assert.deepEqual(x.foo(), {
+        name: 'foo'
+      });
+    } catch (err) {
+      restore();
+      throw err;
+    }
+
+    var output = restore('true');
+    assert(output.indexOf('gulp-load-plugins') !== -1, 'Expected output to be logged to stdout');
   });
 
   it('supports loading scopped package', function() {


### PR DESCRIPTION
Uses gulplog checking code from gulp-util to check if gulplog already exists. Otherwise uses fancy-log. This is to ensure the correct loggers are registered depending on if the gulp 3 cli is used or gulp-cli which handles both gulp 3 and gulp 4.

Fixes #113 