### PR TITLE
Add `gulp-load-plugins/load` for babel users! :+1:

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ plugins.myco.testPlugin();
 In 0.4.0 and prior, lazy loading used to only work with plugins that return a function. In newer versions though, lazy loading should work for any plugin. If you have a problem related to this please try disabling lazy loading and see if that fixes it. Feel free to open an issue on this repo too.
 
 
+## Aggressive loading
+
+use the `gulp-load-plugins/load`, it is also possible to load briefly in the [import statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import).
+
+```js
+// gulpfile.babel.js
+import * as plugins from 'gulp-load-plugins/load';
+```
+
 ## Credit
 
 Credit largely goes to @sindresorhus for his [load-grunt-plugins](https://github.com/sindresorhus/load-grunt-tasks) plugin. This plugin is almost identical, just tweaked slightly to work with Gulp and to expose the required plugins.

--- a/load.js
+++ b/load.js
@@ -1,0 +1,10 @@
+var findup = require('findup-sync');
+var path = require('path');
+var parentDir = path.dirname(module.parent.filename);
+
+module.exports = require('./')({
+  config: findup('package.json', {cwd: parentDir})
+});
+
+// Necessary to get the current `module.parent` and resolve paths correctly.
+delete require.cache[__filename];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "license": "MIT",
   "files": [
-    "index.js"
+    "index.js",
+    "load.js"
   ],
   "repository": "jackfranklin/gulp-load-plugins",
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -273,4 +273,9 @@ describe('common functionality', function () {
     var plugins = require('../')();
     assert.ok(typeof plugins.test === 'function');
   });
+
+  it('allows directly load in a lower directory', function() {
+    var plugins = require('../load');
+    assert.ok(typeof plugins.test === 'function');
+  });
 });


### PR DESCRIPTION
currently, two lines becomes requirements for babel users.

```js
// gulpfile.babel.js
import gulpLoadPlugin from 'gulp-load-plugins';
const plugins = gulpLoadPlugin();
```

this PR is, that can write one line using gulp-load-plugins/load.js. (but, the option are unavailable)

```js
// gulpfile.babel.js
import * as plugins from 'gulp-load-plugins/load';
```