### PR TITLE
configure whether plugins should be nested or not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ gulpLoadPlugins({
     rename: {}, // a mapping of plugins to rename
     renameFn: function (name) { ... }, // a function to handle the renaming of plugins (the default works)
     postRequireTransforms: {}, // see documentation below
-    maintainScope: true // toggles loadin all npm scopes like non-scoped packages
+    maintainScope: true // toggles loading all npm scopes like non-scoped packages
 });
 ```
 
@@ -137,7 +137,7 @@ Note that if you specify the `renameFn` options with your own custom rename func
 
 ## npm Scopes
 
-`gulp-load-plugins` comes with [npm scope](https://docs.npmjs.com/misc/scope) support. By default, the scoped plugins are accessible through an object on `plugins` that represents the scope. When `maintainScope = false`, the plugins are availble in the top level just like any other non-scoped plugins.
+`gulp-load-plugins` comes with [npm scope](https://docs.npmjs.com/misc/scope) support. By default, the scoped plugins are accessible through an object on `plugins` that represents the scope. When `maintainScope = false`, the plugins are available in the top level just like any other non-scoped plugins.
 
 For example, if the plugin is `@myco/gulp-test-plugin` then you can access the plugin as shown in the following example:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ gulpLoadPlugins({
     rename: {}, // a mapping of plugins to rename
     renameFn: function (name) { ... }, // a function to handle the renaming of plugins (the default works)
     postRequireTransforms: {}, // see documentation below
-    scoped: true // loads all npm scopes like non-scoped packages
+    maintainScope: true // toggles loadin all npm scopes like non-scoped packages
 });
 ```
 
@@ -137,19 +137,19 @@ Note that if you specify the `renameFn` options with your own custom rename func
 
 ## npm Scopes
 
-`gulp-load-plugins` comes with [npm scope](https://docs.npmjs.com/misc/scope) support. By default, the scoped plugins are accessible through an object on `plugins` that represents the scope. When `scoped = false`, the plugins are availble in the top level just like any other non-scoped plugins.
+`gulp-load-plugins` comes with [npm scope](https://docs.npmjs.com/misc/scope) support. By default, the scoped plugins are accessible through an object on `plugins` that represents the scope. When `maintainScope = false`, the plugins are availble in the top level just like any other non-scoped plugins.
 
 For example, if the plugin is `@myco/gulp-test-plugin` then you can access the plugin as shown in the following example:
 
 ```js
 var scoped = require('gulp-load-plugins')({
-  scoped: true,
+  maintainScope: true,
 });
 
 scoped.myco.testPlugin();
 
 var nonScoped = require('gulp-load-plugins')({
-  scoped: false,
+  maintainScope: false,
 });
 
 nonScoped.testPlugin();

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ gulpLoadPlugins({
     lazy: true, // whether the plugins should be lazy loaded on demand
     rename: {}, // a mapping of plugins to rename
     renameFn: function (name) { ... }, // a function to handle the renaming of plugins (the default works)
-    postRequireTransforms: {} // see documentation below
+    postRequireTransforms: {}, // see documentation below
+    scoped: true // loads all npm scopes like non-scoped packages
 });
 ```
 
@@ -136,12 +137,22 @@ Note that if you specify the `renameFn` options with your own custom rename func
 
 ## npm Scopes
 
-`gulp-load-plugins` comes with [npm scope](https://docs.npmjs.com/misc/scope) support. The major difference is that scoped plugins are accessible through an object on `plugins` that represents the scope. For example, if the plugin is `@myco/gulp-test-plugin` then you can access the plugin as shown in the following example:
+`gulp-load-plugins` comes with [npm scope](https://docs.npmjs.com/misc/scope) support. By default, the scoped plugins are accessible through an object on `plugins` that represents the scope. When `scoped = false`, the plugins are availble in the top level just like any other non-scoped plugins.
+
+For example, if the plugin is `@myco/gulp-test-plugin` then you can access the plugin as shown in the following example:
 
 ```js
-var plugins = require('gulp-load-plugins')();
+var scoped = require('gulp-load-plugins')({
+  scoped: true,
+});
 
-plugins.myco.testPlugin();
+scoped.myco.testPlugin();
+
+var nonScoped = require('gulp-load-plugins')({
+  scoped: false,
+});
+
+nonScoped.testPlugin();
 ```
 
 ## Lazy Loading

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = function(options) {
   var camelizePluginName = options.camelize !== false;
   var lazy = 'lazy' in options ? !!options.lazy : true;
   var renameObj = options.rename || {};
+  var nested = 'nested' in options ? !!options.nested : true;
 
   logDebug('Debug enabled with options: ' + JSON.stringify(options));
 
@@ -139,16 +140,19 @@ module.exports = function(options) {
 
   unique(micromatch(names, pattern)).forEach(function(name) {
     var decomposition;
+    var fObject = finalObject;
     if (scopeTest.test(name)) {
       decomposition = scopeDecomposition.exec(name);
-
-      if (!finalObject.hasOwnProperty(decomposition[1])) {
-        finalObject[decomposition[1]] = {};
+      if (nested) {
+        if (!fObject.hasOwnProperty(decomposition[1])) {
+          finalObject[decomposition[1]] = {};
+        }
+        fObject = finalObject[decomposition[1]];
       }
 
-      defineProperty(finalObject[decomposition[1]], applyTransform, getRequireName(decomposition[2]), name);
+      defineProperty(fObject, applyTransform, getRequireName(decomposition[2]), name);
     } else {
-      defineProperty(finalObject, applyTransform, getRequireName(name), name);
+      defineProperty(fObject, applyTransform, getRequireName(name), name);
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function(options) {
   var camelizePluginName = options.camelize !== false;
   var lazy = 'lazy' in options ? !!options.lazy : true;
   var renameObj = options.rename || {};
-  var nested = 'nested' in options ? !!options.nested : true;
+  var scoped = 'scoped' in options ? !!options.scoped : true;
 
   logDebug('Debug enabled with options: ' + JSON.stringify(options));
 
@@ -143,7 +143,7 @@ module.exports = function(options) {
     var fObject = finalObject;
     if (scopeTest.test(name)) {
       decomposition = scopeDecomposition.exec(name);
-      if (nested) {
+      if (scoped) {
         if (!fObject.hasOwnProperty(decomposition[1])) {
           finalObject[decomposition[1]] = {};
         }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function(options) {
   var camelizePluginName = options.camelize !== false;
   var lazy = 'lazy' in options ? !!options.lazy : true;
   var renameObj = options.rename || {};
-  var scoped = 'scoped' in options ? !!options.scoped : true;
+  var maintainScope = 'maintainScope' in options ? !!options.maintainScope : true;
 
   logDebug('Debug enabled with options: ' + JSON.stringify(options));
 
@@ -143,7 +143,7 @@ module.exports = function(options) {
     var fObject = finalObject;
     if (scopeTest.test(name)) {
       decomposition = scopeDecomposition.exec(name);
-      if (scoped) {
+      if (maintainScope) {
         if (!fObject.hasOwnProperty(decomposition[1])) {
           finalObject[decomposition[1]] = {};
         }

--- a/index.js
+++ b/index.js
@@ -89,10 +89,14 @@ module.exports = function(options) {
     }
   }
 
-  function defineProperty(object, transform, requireName, name) {
+  function defineProperty(object, transform, requireName, name, maintainScope) {
+    var err;
     if (object[requireName]) {
       logDebug('error: defineProperty ' + name);
-      throw new Error('Could not define the property "' + requireName + '", you may have repeated dependencies in your package.json like' + ' "gulp-' + requireName + '" and ' + '"' + requireName + '"');
+      err = maintainScope ?
+        'Could not define the property "' + requireName + '", you may have repeated dependencies in your package.json like' + ' "gulp-' + requireName + '" and ' + '"' + requireName + '"' :
+        'Could not define the property "' + requireName + '", you may have repeated a dependency in another scope like' + ' "gulp-' + requireName + '" and ' + '"@foo/gulp-' + requireName + '"';
+      throw new Error(err);
     }
 
     if (lazy) {
@@ -150,9 +154,9 @@ module.exports = function(options) {
         fObject = finalObject[decomposition[1]];
       }
 
-      defineProperty(fObject, applyTransform, getRequireName(decomposition[2]), name);
+      defineProperty(fObject, applyTransform, getRequireName(decomposition[2]), name, maintainScope);
     } else {
-      defineProperty(fObject, applyTransform, getRequireName(name), name);
+      defineProperty(fObject, applyTransform, getRequireName(name), name, maintainScope);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "Carlos Henrique",
     "iamfrontender <iamfrontender@gmail.com>",
     "Brian Woodward",
-    "Zach Schnackel <info@zslabs.com>"
+    "Zach Schnackel <info@zslabs.com>",
+    "Bret K. Ikehara <bret.k.ikehara@gmail.com>"
   ],
   "dependencies": {
     "array-unique": "^0.2.1",

--- a/test/index.js
+++ b/test/index.js
@@ -169,13 +169,23 @@ var commonTests = function(lazy) {
     assert(output.indexOf('gulp-load-plugins') !== -1, 'Expected output to be logged to stdout');
   });
 
-  it('supports loading scopped package', function() {
+  it('supports loading scopped package nested', function() {
     var x = gulpLoadPlugins({
       lazy: lazy,
       config: { dependencies: { '@myco/gulp-test-plugin': '1.0.0' } }
     });
 
     assert.deepEqual(x.myco.testPlugin(), { name: 'test' });
+  });
+
+  it('supports loading scopped package not nested', function() {
+    var x = gulpLoadPlugins({
+      lazy: lazy,
+      nested: false,
+      config: { dependencies: { '@myco/gulp-test-plugin': '1.0.0' } }
+    });
+
+    assert.deepEqual(x.testPlugin(), { name: 'test' });
   });
 
   it('supports custom rename functions', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -181,7 +181,7 @@ var commonTests = function(lazy) {
   it('supports loading scopped package as a top-level reference', function() {
     var x = gulpLoadPlugins({
       lazy: lazy,
-      scoped: false,
+      maintainScope: false,
       config: { dependencies: { '@myco/gulp-test-plugin': '1.0.0' } }
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,20 @@ describe('configuration', function() {
       });
     }, /Could not define the property "bar", you may have repeated dependencies in your package.json like "gulp-bar" and "bar"/);
   });
+
+  it("throws a nice error if there're repeated package names pattern in package.json ", function() {
+    assert.throws(function() {
+      gulpLoadPlugins({
+        config: {
+          dependencies: {
+            '@foo/gulp-bar': '*',
+            'gulp-bar': '~0.0.12'
+          }
+        },
+        maintainScope: false
+      });
+    }, /Could not define the property "bar", you may have repeated a dependency in another scope like "gulp-bar" and "@foo\/gulp-bar"/);
+  });
 });
 
 // Contains common tests with and without lazy mode.

--- a/test/index.js
+++ b/test/index.js
@@ -169,7 +169,7 @@ var commonTests = function(lazy) {
     assert(output.indexOf('gulp-load-plugins') !== -1, 'Expected output to be logged to stdout');
   });
 
-  it('supports loading scopped package nested', function() {
+  it('supports loading scopped package as a nested reference', function() {
     var x = gulpLoadPlugins({
       lazy: lazy,
       config: { dependencies: { '@myco/gulp-test-plugin': '1.0.0' } }
@@ -178,10 +178,10 @@ var commonTests = function(lazy) {
     assert.deepEqual(x.myco.testPlugin(), { name: 'test' });
   });
 
-  it('supports loading scopped package not nested', function() {
+  it('supports loading scopped package as a top-level reference', function() {
     var x = gulpLoadPlugins({
       lazy: lazy,
-      nested: false,
+      scoped: false,
       config: { dependencies: { '@myco/gulp-test-plugin': '1.0.0' } }
     });
 


### PR DESCRIPTION
allow user to configure whether plugin should be referenced using its package. Default behavior preserves package scope nesting.
### maintainScope = true

``` js
var x = require('gulp-load-plugins')({
   scoped: true,
});
x.myco.testPlugin();
```
### maintainScope = false

``` js
var x = require('gulp-load-plugins')({
   scoped: false,
});
x.testPlugin();
```
