### PR TITLE
override or extend built-in patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ You can pass in an object of options that are shown below: (the values for the k
 ```js
 gulpLoadPlugins({
     DEBUG: false, // when set to true, the plugin will log info to console. Useful for bug reporting and issue debugging
-    pattern: ['gulp-*', 'gulp.*'], // the glob(s) to search for
+    pattern: ['gulp-*', 'gulp.*', '@*/gulp{-,.}*'], // the glob(s) to search for
+    overridePattern: true, // When true, overrides the built-in patterns. Otherwise, extends built-in patterns matcher list.
     config: 'package.json', // where to find the plugins, by default searched up from process.cwd()
     scope: ['dependencies', 'devDependencies', 'peerDependencies'], // which keys in the config to look within
     replaceString: /^gulp(-|\.)/, // what to remove from the name of the module when adding it to the context
@@ -162,6 +163,23 @@ nonScoped.testPlugin();
 
 In 0.4.0 and prior, lazy loading used to only work with plugins that return a function. In newer versions though, lazy loading should work for any plugin. If you have a problem related to this please try disabling lazy loading and see if that fixes it. Feel free to open an issue on this repo too.
 
+## Override Pattern
+
+In 1.4.0 and prior, configuring the `pattern` option would override the built-in `['gulp-*', 'gulp.*', '@*/gulp{-,.}*']`. If `overridePattern: false`, the configured `pattern` will now extends the built-in matching.
+
+For example, both are equivilant statements.
+```js
+var overridePlugins = require('gulp-load-plugins')({
+  // true is the default value
+  overridePattern: true,
+  pattern: ['gulp-*', 'gulp.*', '@*/gulp{-,.}*', 'foo-bar']
+});
+
+var extendedPlugins = require('gulp-load-plugins')({
+  overridePattern: false,
+  pattern: ['foo-bar']
+});
+```
 
 ## Credit
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,15 @@ function logger() {
   }
 }
 
+function getPattern(options) {
+  var defaultPatterns = ['gulp-*', 'gulp.*', '@*/gulp{-,.}*'];
+  var overridePattern = 'overridePattern' in options ? !!options.overridePattern : true;
+  if (overridePattern) {
+    return arrayify(options.pattern || defaultPatterns);
+  }
+  return defaultPatterns.concat(arrayify(options.pattern));
+}
+
 module.exports = function(options) {
   var finalObject = {};
   var configObject;
@@ -38,7 +47,7 @@ module.exports = function(options) {
   options = options || {};
 
   var DEBUG = options.DEBUG || false;
-  var pattern = arrayify(options.pattern || ['gulp-*', 'gulp.*', '@*/gulp{-,.}*']);
+  var pattern = getPattern(options);
   var config = options.config || findup('package.json', { cwd: parentDir });
   var scope = arrayify(options.scope || ['dependencies', 'devDependencies', 'peerDependencies']);
   var replaceString = options.replaceString || /^gulp(-|\.)/;

--- a/test/index.js
+++ b/test/index.js
@@ -121,6 +121,25 @@ var commonTests = function(lazy) {
     assert(!x.bar);
   });
 
+  it('can extend the patterns', function() {
+    var x = gulpLoadPlugins({
+      lazy: lazy,
+      config: {
+        dependencies: {
+          'jack-foo': '1.0.0',
+          'gulp-bar': '*'
+        }
+      },
+      overridePattern: false,
+      pattern: 'jack-*'
+    });
+
+    assert.deepEqual(x.jackFoo(), {
+      name: 'jack-foo'
+    });
+    assert(x.bar);
+  });
+
   it('allows camelizing to be turned off', function() {
     var x = gulpLoadPlugins({
       lazy: lazy,


### PR DESCRIPTION
I would like to avoid redefining the built-in gulp patterns. `overridePattern` enabled me to check for plugins that do not have the `gulp-` in its package name.

For example, `webpack-stream` is compatible with gulp, but doesn't match the built-in patterns. I would like to load gulp compatible plugins with gulp-load-plugins to keep all plugins consolidated.

available as `@bretkikehara/gulp-load-plugins@1.5.0-alpha` for testing...