### PR TITLE
Bump packages on vulnerability paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   "dependencies": {
     "array-unique": "^0.2.1",
     "fancy-log": "^1.2.0",
-    "findup-sync": "^0.4.0",
+    "findup-sync": "^3.0.0",
     "gulplog": "^1.0.0",
     "has-gulplog": "^0.1.0",
-    "micromatch": "^2.3.8",
+    "micromatch": "^3.1.10",
     "resolve": "^1.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Running `npm audit` on my project showed a few low-level vulnerabilities in the braces package, which is in the dependency tree of this project.

The braces package has this vulnerability:

https://nodesecurity.io/advisories/786

It's fixed as of version 2.3.1.

This updates all copies of the micromatch dependency in the tree to bring in a version of
braces with the fix.